### PR TITLE
Add admin status to user views and create tournament endpoint

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,5 +3,5 @@
   <component name="Black">
     <option name="sdkName" value="Python 3.11 (satduel)" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.12 (satduel)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (satduel)" project-jdk-type="Python SDK" />
 </project>

--- a/.idea/satduel.iml
+++ b/.idea/satduel.iml
@@ -16,7 +16,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.11 (satduel)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="TemplatesService">

--- a/api/models.py
+++ b/api/models.py
@@ -238,11 +238,6 @@ class Tournament(models.Model):
     def participantNumber(self):
         return self.tournamentparticipation_set.count()
 
-    def save(self, *args, **kwargs):
-        if self.start_time and self.duration:
-            self.end_time = self.start_time + self.duration
-        super(Tournament, self).save(*args, **kwargs)
-
 
 class TournamentParticipation(models.Model):
     user = models.ForeignKey(User, on_delete=models.CASCADE)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -127,7 +127,7 @@ class TournamentSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Tournament
-        fields = ['id', 'name', 'start_time', 'end_time', 'participantNumber', 'questionNumber']
+        fields = ['id', 'name', 'description', 'duration', 'start_time', 'end_time', 'participantNumber', 'questionNumber']
 
 
 class TournamentParticipationSerializer(serializers.ModelSerializer):
@@ -135,7 +135,7 @@ class TournamentParticipationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = TournamentParticipation
-        fields = ['id', 'user', 'tournament', 'start_time', 'end_time', 'score', 'last_correct_submission']
+        fields = ['id', 'user', 'tournament', 'start_time', 'end_time', 'score', 'last_correct_submission', 'status']
 
 
 class TournamentQuestionSerializer(serializers.ModelSerializer):

--- a/api/urls.py
+++ b/api/urls.py
@@ -6,6 +6,7 @@ from . import user_views
 from .user_views import CustomRegisterView
 from . import trainer_views as trainer_view
 from . import tournaments_views
+
 urlpatterns = [
     path('questions/', views.get_random_questions, name='get_random_questions'),
     path('get_question/', views.get_question, name='get_question'),
@@ -19,7 +20,8 @@ urlpatterns = [
     path('profile/update_streak/', views.update_streak, name='update_streak'),
     path('profile/search/', views.search_users, name='search_users'),
     path('profile/send_friend_request/', views.send_friend_request, name='send_friend_request'),
-    path('profile/respond_friend_request/<int:request_id>/', views.respond_friend_request, name='respond_friend_request'),
+    path('profile/respond_friend_request/<int:request_id>/', views.respond_friend_request,
+         name='respond_friend_request'),
     path('profile/friend_requests/', views.list_friend_requests, name='list_friend_requests'),
     path('profile/friends/', views.list_friends, name='list_friends'),
     path('profile/view_profile/<int:user_id>/', views.view_profile, name='view_profile'),
@@ -45,8 +47,10 @@ urlpatterns = [
     path('match/set_winner/', views.set_winner, name='set_winner'),
     path('match/set_score/', views.set_score, name='set_score'),
 
-    path('trainer/infinite_question_stats/', trainer_view.get_infinite_question_stats, name='get_infinite_question_stats'),
-    path('trainer/set_infinite_question_stats/', trainer_view.set_infinite_question_stats, name='set_infinite_question_stats'),
+    path('trainer/infinite_question_stats/', trainer_view.get_infinite_question_stats,
+         name='get_infinite_question_stats'),
+    path('trainer/set_infinite_question_stats/', trainer_view.set_infinite_question_stats,
+         name='set_infinite_question_stats'),
     path('trainer/power_sprint_stats/', trainer_view.get_power_sprint_stats, name='get_power_sprint_stats'),
     path('trainer/set_power_sprint_stats/', trainer_view.set_power_sprint_stats, name='set_power_sprint_stats'),
     path('trainer/survival_stats/', trainer_view.get_survival_stats, name='get_survival_stats'),
@@ -56,10 +60,12 @@ urlpatterns = [
     path('tournaments/<int:pk>/', tournaments_views.tournament_detail, name='tournament-detail'),
     path('tournaments/<int:pk>/join/', tournaments_views.join_tournament, name='join-tournament'),
     path('tournaments/<int:pk>/get_participation_info/', tournaments_views.get_participation, name='get-participation'),
-    path('tournaments/<int:pk>/questions/', tournaments_views.get_tournament_questions, name='get-tournament-questions'),
+    path('tournaments/<int:pk>/questions/', tournaments_views.get_tournament_questions,
+         name='get-tournament-questions'),
     path('tournaments/<int:pk>/leaderboard/', tournaments_views.tournament_leaderboard, name='tournament-leaderboard'),
     path('tournaments/<int:pk>/submit-answer/', tournaments_views.submit_answer, name='submit-answer'),
     path('tournaments/<int:pk>/finish/', tournaments_views.finish_participation, name='finish-participation'),
+    path('tournaments/create/', tournaments_views.create_tournament, name='create-tournament'),
 
     path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),

--- a/api/user_views.py
+++ b/api/user_views.py
@@ -33,6 +33,7 @@ def login_view(request):
                     'username': user.username,
                     'email': user.email,
                     'id': user.id,
+                    'is_admin': user.is_staff,
                 }, status=200)
             else:
                 return JsonResponse({'error': 'Please verify your email address before logging in'}, status=401)
@@ -83,6 +84,8 @@ def register(request):
                 'message': 'User registered and logged in successfully',
                 'username': user.username,
                 'email': user.email,
+                'id': user.id,
+                'is_admin': user.is_staff,
             }, status=201)
 
         else:
@@ -91,32 +94,6 @@ def register(request):
         return JsonResponse({'error': 'Invalid HTTP method'}, status=405)
 
 
-
-
-# @method_decorator(csrf_exempt, name='dispatch')
-# class CustomRegisterView(RegisterView):
-#     serializer_class = CustomRegisterSerializer
-#
-#     def create(self, request, *args, **kwargs):
-#         serializer = self.get_serializer(data=request.data)
-#         if serializer.is_valid():
-#             user = serializer.save(request)
-#             email_address = EmailAddress.objects.filter(user=user).first()
-#             response_data = {
-#                 'id': user.id,
-#                 'username': user.username,
-#                 'email': user.email,
-#                 'first_name': user.first_name,
-#                 'last_name': user.last_name,
-#                 'is_active': user.is_active,
-#                 'email_verified': email_address.verified if email_address else False
-#             }
-#             return Response(response_data, status=status.HTTP_201_CREATED)
-#         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-#
-#     def perform_create(self, serializer):
-#         user = serializer.save(self.request)
-#         return user
 
 @method_decorator(csrf_exempt, name='dispatch')
 class CustomRegisterView(RegisterView):


### PR DESCRIPTION
Updated user views to include 'is_admin' in the response data. Removed an outdated `save` method from Tournament model. Added a new API endpoint to create tournaments, and adjusted tournaments filter to exclude private ones.