### PR TITLE
Update battle duration and PDF file path

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -90,7 +90,7 @@ class Room(models.Model):
     status = models.CharField(max_length=10,
                               choices=[('Searching', 'Searching'), ('Battling', 'Battling'), ('Ended', 'Ended')])
     battle_start_time = models.DateTimeField(null=True, blank=True)
-    battle_duration = models.IntegerField(default=20)  # Duration in seconds, default 5 minutes
+    battle_duration = models.IntegerField(default=300)  # Duration in seconds, default 5 minutes
     winner = models.ForeignKey(User, on_delete=models.CASCADE, null=True, blank=True)
     user1_score = models.IntegerField(default=0)
     user2_score = models.IntegerField(default=0)

--- a/api/test.py
+++ b/api/test.py
@@ -65,7 +65,7 @@ def clean_text(text):
 
 
 # Extract text from PDF
-pdf_file_path = 'Cross-Text Connections (Level 1) Answer Key.pdf'
+pdf_file_path = 'Text Structure and Purpose (Level 1) Answer Key.pdf'
 doc = fitz.open(pdf_file_path)
 text = ""
 for page in doc:


### PR DESCRIPTION
Changed the `battle_duration` default from 20 to 300 seconds, addressing a typo to ensure the duration is 5 minutes. Also updated the PDF file path in `test.py` to reflect the correct document name.